### PR TITLE
support formdata http

### DIFF
--- a/catcher/__init__.py
+++ b/catcher/__init__.py
@@ -1,3 +1,3 @@
 APPNAME = 'catcher'
 APPAUTHOR = 'Valerii Tikhonov'
-APPVSN = '1.20.0'
+APPVSN = '1.20.1'

--- a/catcher/steps/http.py
+++ b/catcher/steps/http.py
@@ -120,16 +120,23 @@ class Http(Step):
         rq = dict(verify=self.verify, headers=headers)
         isjson, body = self.__form_body(variables)
         debug('http ' + str(self.method) + ' ' + str(url) + ', ' + str(headers) + ', ' + str(body))
+        content_type = self.__get_content_type(headers)
         if isjson or isinstance(body, dict):  # contains tojson or dict supplied
-            if 'content-type' not in headers and 'Content-Type' not in headers:  # add json content type if missing
-                headers['content-type'] = 'application/json'
-            if isinstance(body, dict):  # json body formed manually via python dict
+            if isinstance(body, dict) and content_type == 'application/json':
+                # json body formed manually via python dict
                 rq['json'] = body
-            else:  # string, already in json
+            else:  # json string or form-data dict
                 rq['data'] = body
         else:  # raw body (or body is None)
             rq['data'] = body
         return rq
+
+    @staticmethod
+    def __get_content_type(headers):
+        content_type = headers.get('Content-Type')
+        if content_type is None:
+            content_type = headers.get('content-type')
+        return content_type
 
     def __form_body(self, variables) -> str or dict:
         if self.method == 'get':

--- a/test/core/output_test.py
+++ b/test/core/output_test.py
@@ -1,4 +1,3 @@
-import ast
 import json
 from os import listdir
 from os.path import join, isfile
@@ -69,8 +68,12 @@ class OutputTest(TestClass):
             self.assertTrue(steps[1]['success'])
             self.assertEqual('check', list(steps[2]['step'].keys())[0])
             self.assertFalse(steps[3]['success'])
-            self.assertEqual("operation {'any': {'of': '['bar']', 'equals': '404'}} failed", steps[3]['output'])
-            self.assertEqual("operation {'any': {'of': '['bar']', 'equals': '404'}} failed", report['status'])
+            self.assertTrue(self._compare_operations(steps[3]['output'],
+                                                     "operation {'any': {'of': '['bar']', 'equals': '404'}} failed",
+                                                     "operation {'any': {'equals': '404', 'of': '['bar']'}} failed"))
+            self.assertTrue(self._compare_operations(report['status'],
+                                                     "operation {'any': {'of': '['bar']', 'equals': '404'}} failed",
+                                                     "operation {'any': {'equals': '404', 'of': '['bar']'}} failed"))
 
     def test_register_variable(self):
         self.populate_file('main.yaml', '''---
@@ -234,3 +237,8 @@ class OutputTest(TestClass):
             self.assertEqual('run', list(steps[5]['step'].keys())[0])
             self.assertEqual('echo', list(steps[6]['step'].keys())[0])
             self.assertEqual('echo', list(steps[7]['step'].keys())[0])
+
+    # py36 has dict insert ordering, while older implementations have some other.
+    @staticmethod
+    def _compare_operations(operation, *expectations):
+        return any([operation == exp for exp in expectations])


### PR DESCRIPTION
`form-data` content-type header with requests.data is not working in python.
This fix will call requests.data in case there is no content-type `json` selected. 