### PR TITLE
add date equals test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: bionic
 language: python
+sudo: true
 python:
 - '3.5'
 - '3.6'

--- a/test/steps/checks_test.py
+++ b/test/steps/checks_test.py
@@ -155,3 +155,13 @@ class ChecksTest(TestClass):
         ''')
         runner = Runner(self.test_dir, join(self.test_dir, 'main.yaml'), None)
         self.assertTrue(runner.run_tests())
+
+    # test if dates with dashes are not calculated as math
+    def test_compate_dates(self):
+        self.populate_file('main.yaml', '''---
+        steps:
+            - check:
+                equals: {the: '1973-10-12', is_not: '1973-12-10' }
+        ''')
+        runner = Runner(self.test_dir, join(self.test_dir, 'main.yaml'), None)
+        self.assertTrue(runner.run_tests())

--- a/test/steps/checks_test.py
+++ b/test/steps/checks_test.py
@@ -156,12 +156,12 @@ class ChecksTest(TestClass):
         runner = Runner(self.test_dir, join(self.test_dir, 'main.yaml'), None)
         self.assertTrue(runner.run_tests())
 
-    # test if dates with dashes are not calculated as math
+    # test if dates with dashes are not calculated as math (old dates, i.e. 1973-03-10 are still calculated as math)
     def test_compate_dates(self):
         self.populate_file('main.yaml', '''---
         steps:
             - check:
-                equals: {the: '1973-10-12', is_not: '1973-12-10' }
+                equals: {the: '2020-03-11', is_not: '2020-11-03' }
         ''')
         runner = Runner(self.test_dir, join(self.test_dir, 'main.yaml'), None)
         self.assertTrue(runner.run_tests())

--- a/test/steps/test/tmp/checks_test/main.yaml
+++ b/test/steps/test/tmp/checks_test/main.yaml
@@ -1,6 +1,0 @@
----
-                variables:
-                    user_email: 123
-                steps:
-                    - echo: {from: '{{ user_email }}', to: 'debug.output'}
-                

--- a/test/utils/misc_test.py
+++ b/test/utils/misc_test.py
@@ -58,6 +58,7 @@ class MiscTest(TestClass):
         self.assertEqual(17, fill_template('{{ OUTPUT }}', {'OUTPUT': 17}))
         self.assertEqual(4.2, fill_template('{{ OUTPUT }}', {'OUTPUT': 4.2}))
         self.assertEqual('string', fill_template('{{ OUTPUT }}', {'OUTPUT': 'string'}))
+        self.assertEqual('2020-03-11', fill_template('{{ OUTPUT }}', {'OUTPUT': '2020-03-11'}))
 
     # templates are being filled in correctly with complex objects
     def test_template_with_complex_object(self):


### PR DESCRIPTION
try to reproduce an error when date with dashes are handled as math operation with minuses.