### PR TITLE
Formatted output

### DIFF
--- a/catcher/__init__.py
+++ b/catcher/__init__.py
@@ -1,3 +1,3 @@
 APPNAME = 'catcher'
 APPAUTHOR = 'Valerii Tikhonov'
-APPVSN = '1.23.6'
+APPVSN = '1.24.0'

--- a/catcher/__main__.py
+++ b/catcher/__main__.py
@@ -28,6 +28,8 @@ from catcher.core.runner import Runner
 from catcher.utils import logger
 from catcher.utils.logger import warning
 from catcher.utils.module_utils import load_external_actions
+from colorama import init
+init()
 
 
 def main(args=None):

--- a/catcher/core/include.py
+++ b/catcher/core/include.py
@@ -26,7 +26,6 @@ class Include:
         self.alias = keywords.get('as', None)
         self.run_on_include = keywords.get('run_on_include', self.alias is None)
         self.ignore_errors = ignore_errors
-        self.test = None
 
     @staticmethod
     def check_circular(parent: str,

--- a/catcher/core/include.py
+++ b/catcher/core/include.py
@@ -1,0 +1,43 @@
+import networkx as nx
+
+from typing import Tuple, Optional
+
+from catcher.utils.logger import debug
+
+
+class Include:
+    """
+    Include another testcase in include section:
+
+    ::
+        include:
+            - file: simple_file.yaml
+              run_on_include: false
+            - other_simple_file.yaml
+
+    each include file has it's own Include object and attached Test
+    """
+
+    def __init__(self, ignore_errors=False, **keywords) -> None:
+        if 'file' not in keywords:
+            raise RuntimeError('Can\'t include unknown file.')
+        self.file = keywords['file']
+        self.variables = keywords.get('variables', {})
+        self.alias = keywords.get('as', None)
+        self.run_on_include = keywords.get('run_on_include', self.alias is None)
+        self.ignore_errors = ignore_errors
+        self.test = None
+
+    @staticmethod
+    def check_circular(parent: str,
+                       all_includes: Optional[nx.DiGraph],
+                       current_include: dict) -> Tuple[nx.DiGraph, 'Include']:
+        if all_includes is None:
+            all_includes = nx.DiGraph()
+        path = current_include['file']
+        all_includes.add_edge(parent, path)
+        if list(nx.simple_cycles(all_includes)):
+            debug(str(all_includes.edges))
+            raise Exception('Circular dependencies for ' + path)
+        include = Include(**current_include)
+        return all_includes, include

--- a/catcher/core/runner.py
+++ b/catcher/core/runner.py
@@ -61,10 +61,10 @@ class Runner:
                     logger.log_storage.test_start(file)
                     test.run()
                     results.append(True)
-                    info('Test ' + file + ' passed.')
+                    info('Test ' + file + logger.green(' passed.'))
                     logger.log_storage.test_end(file, True)
                 except Exception as e:
-                    warning('Test ' + file + ' failed: ' + str(e))
+                    warning('Test ' + file + logger.red(' failed: ') + str(e))
                     results.append(False)
                     logger.log_storage.test_end(file, False, str(e))
             return all(results)

--- a/catcher/core/test.py
+++ b/catcher/core/test.py
@@ -66,22 +66,22 @@ class Test:
                     self.variables = action_object.action(self.includes, variables)
                     # repeat for run (variables were computed after name)
                     action_name = get_action_name(action, action_object, self.variables)
-                    info('Step ' + action_name + ' OK')
+                    info('Step ' + action_name + logger.green(' OK'))
                     logger.log_storage.step_end(step, self.variables)
                 except StopException as e:  # stop a test without error
                     if raise_stop:  # or raise error if configured
                         logger.log_storage.step_end(step, variables, success=False, output=str(e))
                         raise e
                     debug('Skip ' + action_name + ' due to ' + str(e))
-                    info('Step ' + action_name + ' OK')
+                    info('Step ' + action_name + logger.green(' OK'))
                     logger.log_storage.step_end(step, self.variables, success=True, output=str(e))
                     return self.variables  # stop current test
                 except Exception as e:
                     if ignore_errors:
-                        debug('Step ' + action_name + ' failed, but we ignore it')
+                        debug('Step ' + action_name + logger.red(' failed') + ', but we ignore it')
                         logger.log_storage.step_end(step, variables, success=True)
                         continue
-                    info('Step ' + action_name + ' failed: ' + str(e))
+                    info('Step ' + action_name + logger.red(' failed: ') + str(e))
                     debug(traceback.format_exc())
                     logger.log_storage.step_end(step, variables, success=False, output=str(e))
                     raise e

--- a/catcher/core/test.py
+++ b/catcher/core/test.py
@@ -9,30 +9,6 @@ from catcher.utils.misc import fill_template_str, merge_two_dicts
 from catcher.core import step_factory
 
 
-class Include:
-    """
-    Include another testcase in include section:
-
-    ::
-        include:
-            - file: simple_file.yaml
-              run_on_include: false
-            - other_simple_file.yaml
-
-    each include file has it's own Include object and attached Test
-    """
-
-    def __init__(self, ignore_errors=False, **keywords) -> None:
-        if 'file' not in keywords:
-            raise RuntimeError('Can\'t include unknown file.')
-        self.file = keywords['file']
-        self.variables = keywords.get('variables', {})
-        self.alias = keywords.get('as', None)
-        self.run_on_include = keywords.get('run_on_include', self.alias is None)
-        self.ignore_errors = ignore_errors
-        self.test = None
-
-
 class Test:
     """
     Testcase. Contains variables, includes and steps to run.

--- a/catcher/modules/log_storage.py
+++ b/catcher/modules/log_storage.py
@@ -9,6 +9,7 @@ class LogStorage:
         self._data = []
         self._current_test = None
         self._format = output_format
+        self.nesting_counter = 0
 
     def test_start(self, test: str, test_type='test'):
         self._current_test = {'start_time': datetime.now().strftime("%Y-%m-%d %H:%M:%S"), 'file': test,
@@ -28,6 +29,18 @@ class LogStorage:
         self._data += [{**{'end_time': datetime.now().strftime("%Y-%m-%d %H:%M:%S")}, **self._current_test}]
         self._current_test = None
 
+    def nested_test_in(self):
+        """
+        If test is run from include
+        """
+        self.nesting_counter += 1
+
+    def nested_test_out(self):
+        """
+        If test is run from include
+        """
+        self.nesting_counter -= 1
+
     def new_step(self, step, variables):
         self._current_test['output'] += [{'time': datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                                           'step': self.clean_step_def(step), 'variables': self.clean_vars(variables)}]
@@ -35,7 +48,8 @@ class LogStorage:
     def step_end(self, step, variables, output: str = None, success: bool = True):
         self._current_test['output'] += [{'time': datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                                           'step': self.clean_step_def(step),
-                                          'variables': self.clean_vars(variables), 'success': success, 'output': output}]
+                                          'variables': self.clean_vars(variables), 'success': success,
+                                          'output': output}]
 
     def output(self, level, output):
         if self._current_test:

--- a/catcher/steps/run.py
+++ b/catcher/steps/run.py
@@ -1,7 +1,9 @@
 from catcher.steps.step import Step, update_variables
-from catcher.utils.logger import error
+from catcher.utils.logger import error, info
 from catcher.utils.misc import merge_two_dicts, fill_template_str
 from catcher.steps.stop import StopException
+from catcher.utils import file_utils
+from catcher.utils import logger
 
 
 class Run(Step):
@@ -76,10 +78,15 @@ class Run(Step):
         variables = merge_two_dicts(include.variables, merge_two_dicts(variables, filled_vars))
         include.variables = variables
         try:
+            info('Running {}'.format(test))
+            logger.log_storage.nested_test_in()
             variables = include.run(tag=tag, raise_stop=True)
+            logger.log_storage.nested_test_out()
         except StopException as e:
+            logger.log_storage.nested_test_out()
             raise e
         except Exception as e:
+            logger.log_storage.nested_test_out()
             if not self.ignore_errors:
                 raise Exception('Step run ' + test + ' failed: ' + str(e))
         return variables

--- a/catcher/utils/file_utils.py
+++ b/catcher/utils/file_utils.py
@@ -69,7 +69,7 @@ def ensure_dir(path: str):
 def _read_yaml_file(file: str) -> dict:
     with open(file, 'r') as stream:
         try:
-            return yaml.load(stream) or {}
+            return yaml.load(stream, Loader=yaml.FullLoader) or {}
         except yaml.YAMLError as exc:
             raise yaml.YAMLError('Wrong YAML format for file ' + file + ' : ' + str(exc))
 

--- a/catcher/utils/logger.py
+++ b/catcher/utils/logger.py
@@ -3,8 +3,17 @@ from logging import Logger
 
 import catcher
 from catcher.modules.log_storage import EmptyLogStorage
+from colorama import Fore, Style
 
 log_storage = EmptyLogStorage('empty')
+
+
+def green(output: str) -> str:
+    return Fore.GREEN + output + Style.RESET_ALL
+
+
+def red(output: str) -> str:
+    return Fore.RED + output + Style.RESET_ALL
 
 
 def configure(log_level: str):

--- a/catcher/utils/logger.py
+++ b/catcher/utils/logger.py
@@ -40,24 +40,31 @@ def get_logger() -> Logger:
 
 def debug(msg: str):
     log_storage.output('debug', msg)
-    get_logger().debug(msg)
+    get_logger().debug(_nested_output(msg))
 
 
 def info(msg: str):
     log_storage.output('info', msg)
-    get_logger().info(msg)
+    get_logger().info(_nested_output(msg))
 
 
 def warning(msg: str):
     log_storage.output('warning', msg)
-    get_logger().warning(msg)
+    get_logger().warning(_nested_output(msg))
 
 
 def error(msg: str):
     log_storage.output('error', msg)
-    get_logger().error(msg)
+    get_logger().error(_nested_output(msg))
 
 
 def critical(msg: str):
     log_storage.output('critical', msg)
-    get_logger().critical(msg)
+    get_logger().critical(_nested_output(msg))
+
+
+def _nested_output(msg):
+    if log_storage.nesting_counter > 0:
+        spaces = ''.join(['\t' for i in range(0, log_storage.nesting_counter - 1)])
+        msg = spaces + '|--> ' + str(msg)
+    return msg

--- a/catcher/utils/misc.py
+++ b/catcher/utils/misc.py
@@ -6,7 +6,7 @@ import sys
 import time
 import uuid
 import hashlib
-from collections import Iterable
+from collections.abc import Iterable
 from types import ModuleType
 
 from faker import Faker

--- a/catcher/utils/misc.py
+++ b/catcher/utils/misc.py
@@ -73,7 +73,7 @@ def fill_template(source: any, variables: dict, isjson=False, glob=None, globs_a
                 name = str(e).split("'")[1]
                 if name not in globs_added:
                     # f.e. tzinfo=psycopg2.tz.FixedOffsetTimezone for datetime
-                    glob = module_utils.add_package_to_globals(name, glob)
+                    glob = module_utils.add_package_to_globals(name, glob, warn_missing_package=False)
                     globs_added.add(name)
                     filled = fill_template(source, variables, isjson, glob=glob, globs_added=globs_added)
                     if not isinstance(filled, ModuleType) and not callable(filled):

--- a/catcher/utils/module_utils.py
+++ b/catcher/utils/module_utils.py
@@ -7,7 +7,7 @@ from os.path import join
 from pydoc import locate
 from types import ModuleType
 
-from catcher.utils.logger import warning, error
+from catcher.utils.logger import warning, error, debug
 
 
 def prepare_modules(module_paths: list, available: dict) -> dict:
@@ -65,14 +65,17 @@ def is_package_installed(package: str) -> bool:
         return False
 
 
-def add_package_to_globals(package: str, glob=None) -> dict:
+def add_package_to_globals(package: str, glob=None, warn_missing_package=True) -> dict:
     if glob is None:
         glob = globals()
     try:
         mod = importlib.import_module(package)
         glob[package] = mod
     except ImportError as e:
-        warning(str(e))
+        if warn_missing_package:
+            warning(str(e))
+        else:
+            debug(str(e))
     return glob
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ PyYAML==5.*
 Jinja2==2.11.*
 uuid==1.30
 Faker==4.0.*
+colorama==0.4.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ Jinja2==2.11.*
 uuid==1.30
 Faker==4.0.*
 colorama==0.4.*
+networkx==2.4.*

--- a/test/core/test/tmp/variables_test/main.yaml
+++ b/test/core/test/tmp/variables_test/main.yaml
@@ -1,9 +1,0 @@
----
-                variables:
-                    date: 123
-                    date_object: {'mydate': '{{ date }}'}
-                steps:
-                    - check: 
-                        the: '{{ mydate }}'
-                        is: '2020'
-                


### PR DESCRIPTION
* fixed bug with including same steps from parent and parent's parent test
* colorful outputs (green OK, red failed)
* formatted output for nested steps:
```
INFO:catcher:hello
INFO:catcher:Step echo OK
INFO:catcher:Running inc1
INFO:catcher:|--> value
INFO:catcher:|--> Step echo OK
INFO:catcher:|--> Running inc2
INFO:catcher:   |--> ['bar', 'baz']
INFO:catcher:   |--> Step echo OK
INFO:catcher:|--> Step run OK
INFO:catcher:Step run OK
```