### PR TITLE
fix skip includes

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -65,7 +65,7 @@ Customization
 Catcher can be easily customized to serve your needs.
 
 1. You can write your own functions and filters and use them in your step's `templates <https://catcher-test-tool.readthedocs.io/en/latest/source/filters_and_functions.html>`_.
-2. You can create your own `steps <https://catcher-test-tool.readthedocs.io/en/latest/source/modules.html>`_ (as python script or any executable)
+2. You can create your own `steps <https://catcher-test-tool.readthedocs.io/en/latest/source/modules.html>`_ (in Python, Java, Kotlin, JS, jar-files or any executable)
 3. You can write your steps in catcher itself and `include <https://catcher-test-tool.readthedocs.io/en/latest/source/includes.html#run-on-action>`_ them from other tests.
 
 Usage

--- a/catcher/__init__.py
+++ b/catcher/__init__.py
@@ -1,3 +1,3 @@
 APPNAME = 'catcher'
 APPAUTHOR = 'Valerii Tikhonov'
-APPVSN = '1.31.6'
+APPVSN = '1.31.7'

--- a/catcher/core/parser.py
+++ b/catcher/core/parser.py
@@ -1,7 +1,5 @@
 from typing import Optional, List
 
-from catcher.steps.step import SkipException
-
 from catcher.core.include import Include
 from catcher.core.test import Test
 from catcher.utils.file_utils import read_source_file, get_filename, get_files

--- a/catcher/core/parser.py
+++ b/catcher/core/parser.py
@@ -1,5 +1,7 @@
 from typing import Optional, List
 
+from catcher.steps.step import SkipException
+
 from catcher.core.include import Include
 from catcher.core.test import Test
 from catcher.utils.file_utils import read_source_file, get_filename, get_files
@@ -39,6 +41,9 @@ class Parser:
         for test_file in get_files(test_path):
             try:
                 raw_test = self.read_test(test_file)
+                if raw_test.ignore:  # ignore the test - do not need to check imports (they may be missing)
+                    results += [ParseResult(raw_test, run_on_include=[])]
+                    continue
                 run_on_include = self.fill_includes_recursive(test_file, raw_test, None)
                 results += [ParseResult(raw_test, run_on_include=run_on_include)]
             except Exception as e:

--- a/test/core/e2e_test.py
+++ b/test/core/e2e_test.py
@@ -130,12 +130,25 @@ class E2ETest(TestClass):
                                                 equals: {the: 'life', is: 'life'}
                                         ''')
         output = self._run_test(self.test_dir + ' --no-color', expected_code=1)
-        print(output)
         lines = output.strip().split('\n')
         to_compare = sorted(lines[-3:])  # need to sort it, as output order is not guaranteed in CI
         self.assertEqual('INFO:catcher:Test run 2. Success: 1, Fail: 1. Total: 50%', to_compare[-3])
         self.assertEqual('Test three: pass', to_compare[-2])
         self.assertEqual('Test two: fail, on step 2', to_compare[-1])
+
+    def test_failed_include_ignore_test(self):
+        self.populate_file('two.yaml', '''---
+                                        include: non_existent.yaml
+                                        ignore: true
+                                        steps:
+                                            - echo: 'hello world'
+                                        ''')
+        output = self._run_test(self.test_dir + ' --no-color')
+        print(output)
+        lines = output.strip().split('\n')
+        to_compare = sorted(lines[-3:])  # need to sort it, as output order is not guaranteed in CI
+        self.assertEqual('INFO:catcher:Test run 1. Success: 0, Fail: 0, Skipped: 1. Total: 100%', to_compare[0])
+        self.assertEqual('INFO:catcher:Test two skipped.', to_compare[1])
 
     def test_check_output_run_on_action(self):
         self.populate_step('steps/include.yaml', '''---


### PR DESCRIPTION
in case test is marked as ignored - we shouldn't go through it's includes (as they can be missing, which cause this test to fail). 