### PR TITLE
fix modules load order

### DIFF
--- a/catcher/__init__.py
+++ b/catcher/__init__.py
@@ -1,3 +1,3 @@
 APPNAME = 'catcher'
 APPAUTHOR = 'Valerii Tikhonov, Ekaterina Belova'
-APPVSN = '1.33.3'
+APPVSN = '1.33.4'

--- a/catcher/core/runner.py
+++ b/catcher/core/runner.py
@@ -26,10 +26,11 @@ class Runner:
                  resources=None,
                  output_format=None,
                  filter_list=None) -> None:
-        # singletons init should be done before services, as singletons maybe used there
+        # singletons init should be done before services (like vars holder), as singletons maybe used there
+        # modules should be done before filters, as requirements module installs dependencies for custom bifs
+        ModulesFactory(resources_dir=resources or os.path.join(path, 'resources'))
         FiltersFactory(custom_modules=filter_list)
         StepFactory(modules)
-        ModulesFactory(resources_dir=resources or os.path.join(path, 'resources'))
 
         self.tests_path = tests_path
         self.path = path


### PR DESCRIPTION
fixed singletons initialization order to let modules loader load requiments module which will install deps for custom bifs (filters module) before filters module is loaded.

Correct load order:
1. ModulesFactory
2. Requirements module installs custom requirements
3. FiltersFactory loads custom filters which may use custom deps