### PR TITLE
py file echo support

### DIFF
--- a/catcher/__init__.py
+++ b/catcher/__init__.py
@@ -1,3 +1,3 @@
 APPNAME = 'catcher'
 APPAUTHOR = 'Valerii Tikhonov, Ekaterina Belova'
-APPVSN = '1.33.6'
+APPVSN = '1.34.0'

--- a/catcher/steps/echo.py
+++ b/catcher/steps/echo.py
@@ -5,7 +5,7 @@ from catcher.steps.step import Step, update_variables
 from catcher.utils.file_utils import read_file
 from catcher.utils.logger import info
 from catcher.utils.misc import fill_template, fill_template_str
-from catcher.utils import file_utils
+from catcher.utils import file_utils, module_utils
 
 
 class Echo(Step):
@@ -56,9 +56,7 @@ class Echo(Step):
     @update_variables
     def action(self, includes: dict, variables: dict) -> tuple:
         if self.source_file:  # read from file
-            resources = variables['RESOURCES_DIR']
-            out = fill_template_str(read_file(join(resources, fill_template_str(self.source_file, variables))),
-                                    variables)
+            out = self._read_file(variables)
         else:
             out = fill_template(self.source, variables)
         if self.dst is None:
@@ -71,3 +69,18 @@ class Echo(Step):
             with open(filename, 'w') as f:
                 f.write(str(out))
         return variables, out
+
+    def _read_file(self, variables):
+        resources = variables['RESOURCES_DIR']
+        file = join(resources, fill_template_str(self.source_file, variables))
+        if self.source_file.endswith('.py'):
+            try:
+                read = module_utils.load_external_actions(file)
+                if read is None:
+                    raise Exception("Can't parse file")
+                external = [f for f in dir(read) if not f.startswith('__')]  # load not internal values as output
+                return dict([(n, getattr(read, n)) for n in external])
+            except Exception:  # if we can't parse python file - return it as string (old normal way)
+                return fill_template_str(read_file(file), variables)
+        else:
+            return fill_template_str(read_file(file), variables)

--- a/catcher/steps/step.py
+++ b/catcher/steps/step.py
@@ -1,3 +1,4 @@
+import types
 from abc import abstractmethod
 from functools import wraps
 

--- a/test/steps/echo_test.py
+++ b/test/steps/echo_test.py
@@ -60,3 +60,22 @@ class ChecksTest(TestClass):
         runner = Runner(self.test_dir, join(self.test_dir, 'main.yaml'), None)
         self.assertTrue(runner.run_tests())
         self.assertTrue(check_file(join(self.test_dir, 'resources/foo/bar/bar.json'), '123'))
+
+    def test_read_python_file(self):
+        self.populate_resource('config.py', '''
+my_var = 123
+my_dict = dict(first=1, second=2)
+my_list = [1,2,3]        
+        ''')
+        self.populate_file('main.yaml', '''---
+                                steps:
+                                    - echo:
+                                        from_file: "config.py"
+                                        register: {"data": "{{ OUTPUT }}"}
+                                    - check: {equals: {the: '{{ data.my_var }}', is: 123}}
+                                    - check: {equals: {the: '{{ data.my_dict.first }}', is: 1}}
+                                    - check: {equals: {the: '{{ data.my_dict.second }}', is: 2}}
+                                    - check: {equals: {the: '{{ data.my_list[0] }}', is: 1}}
+                                ''')
+        runner = Runner(self.test_dir, join(self.test_dir, 'main.yaml'), None)
+        self.assertTrue(runner.run_tests())


### PR DESCRIPTION
Echo step can now load and parse python files as source files:
**config.py**
```
my_var = 123
my_dict = dict(first=1, second=2)
my_list = [1,2,3]  
```
**my_test.yml**
```
steps:
      - echo:
          from_file: "config.py"
          register: {"data": "{{ OUTPUT }}"}
      - check: {equals: {the: '{{ data.my_var }}', is: 123}}
      - check: {equals: {the: '{{ data.my_dict.first }}', is: 1}}
      - check: {equals: {the: '{{ data.my_dict.second }}', is: 2}}
      - check: {equals: {the: '{{ data.my_list[0] }}', is: 1}}
```
